### PR TITLE
feat: add an eta/core subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,20 @@
   "types": "./dist/types/index.d.ts",
   "source": "src/index.ts",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "browser": "./dist/browser.umd.js",
-    "import": "./dist/eta.module.mjs",
-    "require": "./dist/eta.umd.js",
-    "default": "./dist/eta.umd.js"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "browser": "./dist/browser.umd.js",
+      "import": "./dist/eta.module.mjs",
+      "require": "./dist/eta.umd.js",
+      "default": "./dist/eta.umd.js"
+    },
+    "./core": {
+      "types": "./dist/types/browser.d.ts",
+      "browser": "./dist/browser.umd.js",
+      "import": "./dist/browser.module.mjs",
+      "require": "./dist/browser.umd.js",
+      "default": "./dist/browser.umd.js"
+    }
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
This PR adds a subpath export so that `eta/core` can be imported/required in runtimes without "node:fs", i.e. CF Workers.