### PR TITLE
Add outputFunctionName config property

### DIFF
--- a/src/compile-string.ts
+++ b/src/compile-string.ts
@@ -38,6 +38,10 @@ function layout(path, data) {
     config.useWith ? "with(" + config.varName + "||{}){" : ""
   }
 
+function ${config.outputFunctionName}(s) {
+    __eta.res += s;
+}
+
 ${compileBody.call(this, buffer)}
 if (__eta.layout) {
   __eta.res = ${

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,9 @@ export interface EtaConfig {
   /** Function applied to all interpolations when autoFilter is true */
   filterFunction: (val: unknown) => string;
 
+  /** Name of the function that can be used in template code to output text to the result (like EJS's `outputFunctionName`). */
+  outputFunctionName: string;
+
   /** Raw JS code inserted in the template function. Useful for declaring global variables for user templates */
   functionHeader: string;
 
@@ -90,6 +93,7 @@ const defaultConfig: EtaConfig = {
   escapeFunction: XMLEscape,
   // default filter function (not used unless enables) just stringifies the input
   filterFunction: (val) => String(val),
+  outputFunctionName: 'output',
   functionHeader: "",
   parse: {
     exec: "",


### PR DESCRIPTION
Add an `outputFunctionName` config property, which defaults to `output`, that behaves like EJS's `outputFunctionName`.

Closes #284 