### PR TITLE
fix: use correct path for types exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./index.d.ts"
+      "types": "./dist/index.d.ts"
     },
     "./core": {
       "import": "./dist/core.js",


### PR DESCRIPTION
The current package.json has an incorrect path, it leads to this error:

```
src/base-class.ts:7:21 - error TS2307: Cannot find module 'eta' or its corresponding type declarations.

7 import { Eta } from 'eta';
                      ~~~~~


Found 1 error in src/base-class.ts:7
```